### PR TITLE
Fixes

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -25,7 +25,7 @@ resource "aws_autoscaling_group" "concourse_web" {
 }
 
 resource "aws_autoscaling_group" "worker" {
-  depends_on = [aws_autoscaling_group.concourse_web]
+  depends_on       = [aws_autoscaling_group.concourse_web]
   name_prefix      = "concourse-worker-"
   max_size         = var.concourse_worker_conf.count
   min_size         = var.concourse_worker_conf.count

--- a/asg.tf
+++ b/asg.tf
@@ -25,6 +25,7 @@ resource "aws_autoscaling_group" "concourse_web" {
 }
 
 resource "aws_autoscaling_group" "worker" {
+  depends_on = [aws_autoscaling_group.concourse_web]
   name_prefix      = "concourse-worker-"
   max_size         = var.concourse_worker_conf.count
   min_size         = var.concourse_worker_conf.count

--- a/files/concourse_web/web_bootstrap.sh
+++ b/files/concourse_web/web_bootstrap.sh
@@ -9,12 +9,12 @@ export CONCOURSE_PASSWORD=${concourse_password}
 mkdir -p /etc/concourse
 
 # Obtain keys from AWS Secrets Manager
-aws secretsmanager get-secret-value --secret-id ${session_signing_key_private_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/session_signing_key
-aws secretsmanager get-secret-value --secret-id ${session_signing_key_public_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/session_signing_key.pub
-aws secretsmanager get-secret-value --secret-id ${tsa_host_key_private_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/tsa_host_key
-aws secretsmanager get-secret-value --secret-id ${tsa_host_key_public_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/tsa_host_key.pub
-aws secretsmanager get-secret-value --secret-id ${worker_key_private_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/worker_key
-aws secretsmanager get-secret-value --secret-id ${worker_key_public_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/worker_key.pub
+aws secretsmanager get-secret-value --secret-id ${session_signing_key_private_secret_arn} --query SecretString --output text > /etc/concourse/session_signing_key
+aws secretsmanager get-secret-value --secret-id ${session_signing_key_public_secret_arn} --query SecretString --output text  > /etc/concourse/session_signing_key.pub
+aws secretsmanager get-secret-value --secret-id ${tsa_host_key_private_secret_arn} --query SecretString --output text > /etc/concourse/tsa_host_key
+aws secretsmanager get-secret-value --secret-id ${tsa_host_key_public_secret_arn} --query SecretString --output text > /etc/concourse/tsa_host_key.pub
+aws secretsmanager get-secret-value --secret-id ${worker_key_private_secret_arn} --query SecretString --output text > /etc/concourse/worker_key
+aws secretsmanager get-secret-value --secret-id ${worker_key_public_secret_arn} --query SecretString --output text > /etc/concourse/worker_key.pub
 cp /etc/concourse/worker_key.pub /etc/concourse/authorized_worker_keys
 
 

--- a/files/concourse_worker/worker_bootstrap.sh
+++ b/files/concourse_worker/worker_bootstrap.sh
@@ -12,8 +12,8 @@ export HOSTNAME=${name}-$AWS_AZ-$UUID
 mkdir -p /etc/concourse
 
 # Obtain keys from AWS Secrets Manager
-aws secretsmanager get-secret-value --secret-id ${tsa_host_key_public_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/tsa_host_key.pub
-aws secretsmanager get-secret-value --secret-id ${worker_key_private_secret_arn} --query SecretBinary --output text | base64 -d > /etc/concourse/worker_key
+aws secretsmanager get-secret-value --secret-id ${tsa_host_key_public_secret_arn} --query SecretString --output text > /etc/concourse/tsa_host_key.pub
+aws secretsmanager get-secret-value --secret-id ${worker_key_private_secret_arn} --query SecretString --output text > /etc/concourse/worker_key
 
 hostnamectl set-hostname $HOSTNAME
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,6 @@ locals {
   zone_names  = data.aws_availability_zones.current.names
 
   common_tags = {
-    Name        = local.name
     Environment = local.environment
     Application = local.name
     Terraform   = "true"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "vpc_id" {
   value = module.vpc.vpc_id
 }
+
+output "concourse_web_dns" {
+  value = "https://${local.fqdn}"
+}


### PR DESCRIPTION
SecretsManager wants `SecretString` not `SecretBinary`
`Name` not required in `common_tags`
New output for FQDN
Add a dependency for the `worker` ASG so that on first deployment it won't bring up workers before web nodes