### PR TITLE
Enable custom worker role plus fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The example above will create 2 teams in addition to `main` team, `infra` and `a
 
 For details on Concourse user roles see [Concourse documentation](https://concourse-ci.org/user-roles.html).
 
-### Using custom IAM role with Concourse workers to enable cross-account
+### Using custom IAM role with Concourse workers to enable cross-account access
 By default this module will create an IAM role and associate it with worker instance profile. This role will be allowed to assume `ci` IAM role in the same account. However in more advanced scenarios where Concourse workers have to assume cross-account roles you'll have to create those roles and provide input to the module.
 * `instance_iam_role` - (Optional) A string specifying name of the IAM role that will be associated with Concourse worker instance profile. The role must exist and have a trust policy set up so that EC2 service is allowed to assume it. 
 * `worker_assume_ci_roles` - (Optional) - A list of IAM role ARNs that worker instance should be allowed to assume. 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ By default this module will create an IAM role and associate it with worker inst
 
 Example:
 Imagine a scenario with two AWS accounts, one called `mgmt` and another `dev`. Concourse is deployed to `mgmt` but should also be able to access `dev`. To enable this,
-* create a role name `ci-worker` in `mgmt` account
+* create a role named `ci-worker` in `mgmt` account
 * create a role named `ci` in both accounts
 * configure both `ci` roles with trust policy that adds `arn:aws:iam::<mgmt-account-id>:role/ci-worker` to trusted entities
 * when calling this module in `mgmt`, set

--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ The example above will create 2 teams in addition to `main` team, `infra` and `a
 * members of `saml-group-name-guest` SAML group will be given `viewer` role within the team.
 
 For details on Concourse user roles see [Concourse documentation](https://concourse-ci.org/user-roles.html).
+
+### Using custom IAM role with Concourse workers to enable cross-account
+By default this module will create an IAM role and associate it with worker instance profile. This role will be allowed to assume `ci` IAM role in the same account. However in more advanced scenarios where Concourse workers have to assume cross-account roles you'll have to create those roles and provide input to the module.
+* `instance_iam_role` - (Optional) A string specifying name of the IAM role that will be associated with Concourse worker instance profile. The role must exist and have a trust policy set up so that EC2 service is allowed to assume it. 
+* `worker_assume_ci_roles` - (Optional) - A list of IAM role ARNs that worker instance should be allowed to assume. 
+
+Example:
+Imagine a scenario with two AWS accounts, one called `mgmt` and another `dev`. Concourse is deployed to `mgmt` but should also be able to access `dev`. To enable this,
+* create a role name `ci-worker` in `mgmt` account
+* create a role named `ci` in both accounts
+* configure both `ci` roles with trust policy that adds `arn:aws:iam::<mgmt-account-id>:role/ci-worker` to trusted entities
+* when calling this module in `mgmt`, set
+    * `instance_iam_role` to `ci-worker`
+    * `worker_assume_ci_roles` to `[<ARN of ci role in mgmt>, <ARN of ci role in dev>]`

--- a/asg.tf
+++ b/asg.tf
@@ -55,7 +55,6 @@ resource "aws_autoscaling_group" "worker" {
     preferences {
       min_healthy_percentage = 0
     }
-    #triggers = ["launch_template"]
   }
 
   enabled_metrics = [

--- a/asg.tf
+++ b/asg.tf
@@ -43,11 +43,19 @@ resource "aws_autoscaling_group" "worker" {
 
   launch_template {
     id      = aws_launch_template.concourse_worker.id
-    version = "$Latest"
+    version = aws_launch_template.concourse_worker.latest_version
   }
 
   lifecycle {
     create_before_destroy = true
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 0
+    }
+    #triggers = ["launch_template"]
   }
 
   enabled_metrics = [

--- a/files/concourse_worker/worker_bootstrap.sh
+++ b/files/concourse_worker/worker_bootstrap.sh
@@ -19,6 +19,11 @@ chmod 0600 /etc/concourse/*
 hostnamectl set-hostname $HOSTNAME
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME
 
+# Git etc expect ca-certificates.crt, not ca-bundle.crt
+ln -s /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+#echo abc
+
 touch /var/spool/cron/root
 echo "*/3 * * * * /home/root/healthcheck.sh" >> /var/spool/cron/root
 chmod 644 /var/spool/cron/root

--- a/files/concourse_worker/worker_bootstrap.sh
+++ b/files/concourse_worker/worker_bootstrap.sh
@@ -22,8 +22,6 @@ aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME
 # Git etc expect ca-certificates.crt, not ca-bundle.crt
 ln -s /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 
-#echo abc
-
 touch /var/spool/cron/root
 echo "*/3 * * * * /home/root/healthcheck.sh" >> /var/spool/cron/root
 chmod 644 /var/spool/cron/root

--- a/variables.tf
+++ b/variables.tf
@@ -85,13 +85,15 @@ variable "concourse_web_conf" {
 variable "concourse_worker_conf" {
   description = "Concourse Worker config options"
   type = object({
-    instance_type         = string
-    count                 = number
-    environment_override  = map(string)
-    garden_network_pool   = string
-    garden_max_containers = string
-    log_level             = string
-    key_name              = string
+    instance_iam_role      = string
+    worker_assume_ci_roles = list(string)
+    instance_type          = string
+    count                  = number
+    environment_override   = map(string)
+    garden_network_pool    = string
+    garden_max_containers  = string
+    log_level              = string
+    key_name               = string
     asg_scaling_config = object({
       night = object({
         min_size         = number
@@ -108,13 +110,15 @@ variable "concourse_worker_conf" {
     })
   })
   default = {
-    instance_type         = "t2.2xlarge"
-    count                 = 3
-    environment_override  = {}
-    garden_network_pool   = "172.16.0.0/21"
-    garden_max_containers = "350"
-    log_level             = "error"
-    key_name              = null
+    instance_iam_role      = null
+    worker_assume_ci_roles = null
+    instance_type          = "t2.2xlarge"
+    count                  = 3
+    environment_override   = {}
+    garden_network_pool    = "172.16.0.0/21"
+    garden_max_containers  = "350"
+    log_level              = "error"
+    key_name               = null
     asg_scaling_config = {
       night = {
         min_size         = 1


### PR DESCRIPTION
* Allow use of a custom Concourse worker IAM role to enable cross-account access
    * Add input vars
    * Do not create worker role if one is supplied
    * Allow specifying custom assume-role policy
* Add `instance_refresh` to enable worker instance replacement on launch template updates
* Create a symlink to CA cert bundle to fix incompatibility between Concourse and AL2